### PR TITLE
make start doesn't exist

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -28,7 +28,7 @@ What that command does is:
 You can now start the server :
 
 ```
-make start
+make daemon
 ```
 
 You can verify that your server is running by going on the url : `http://127.0.0.1:3000/application/spec`


### PR DESCRIPTION
```
(env) guillaumefe@Mrvn flask-api % cat Makefile
.DEFAULT_GOAL := help


### QUICK
# ¯¯¯¯¯¯¯

install: server.install ## Install

daemon: server.daemon ## Start

stop: server.stop ## Stop


include makefiles/server.mk
include makefiles/test.mk
include makefiles/database.mk
include makefiles/format.mk
include makefiles/help.mk
```
make daemon exists
or
make server.starts
```
(env) guillaumefe@Mrvn flask-api % cat makefiles/server.mk
### SERVER
# ¯¯¯¯¯¯¯¯¯¯¯

server.install: ## Install server with its dependencies
	docker-compose run --rm server pip install -r requirements-dev.txt --user --upgrade --no-warn-script-location

server.start: ## Start server in its docker container
	docker-compose up server

server.bash: ## Connect to server to lauch commands
	docker-compose exec server bash

server.daemon: ## Start daemon server in its docker container
	docker-compose up -d server

server.stop: ## Start server in its docker container
	docker-compose stop

server.logs: ## Display server logs
	tail -f server.log

server.upgrade: ## Upgrade pip dependencies
	docker-compose run --rm server bash -c "python vendor/bin/pip-upgrade requirements.txt requirements-dev.txt --skip-virtualenv-check"
```
